### PR TITLE
feat: support configurable model type

### DIFF
--- a/bin/train_model.py
+++ b/bin/train_model.py
@@ -20,7 +20,7 @@ from gluonts.dataset.field_names import FieldName
 import uncond_ts_diff.configs as diffusion_configs
 from uncond_ts_diff.dataset import get_gts_dataset
 from uncond_ts_diff.model.callback import EvaluateCallback
-from uncond_ts_diff.model import TSDiff
+from uncond_ts_diff.model import TSDiff, FourierDiffusion
 from uncond_ts_diff.sampler import DDPMGuidance, DDIMGuidance
 from uncond_ts_diff.utils import (
     create_transforms,
@@ -32,9 +32,15 @@ from uncond_ts_diff.utils import (
 
 guidance_map = {"ddpm": DDPMGuidance, "ddim": DDIMGuidance}
 
+model_map = {
+    "tsdiff": TSDiff,
+    "fourier": FourierDiffusion,
+}
+
 
 def create_model(config):
-    model = TSDiff(
+    Model = model_map[config["model_type"]]
+    model = Model(
         **getattr(diffusion_configs, config["diffusion_config"]),
         freq=config["freq"],
         use_features=config["use_features"],

--- a/configs/train_tsdiff.yaml
+++ b/configs/train_tsdiff.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_electricity.yaml
+++ b/configs/train_tsdiff/train_electricity.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_exchange.yaml
+++ b/configs/train_tsdiff/train_exchange.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_kdd_cup.yaml
+++ b/configs/train_tsdiff/train_kdd_cup.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_m4.yaml
+++ b/configs/train_tsdiff/train_m4.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_electricity.yaml
+++ b/configs/train_tsdiff/train_missing_electricity.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_exchange.yaml
+++ b/configs/train_tsdiff/train_missing_exchange.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_kdd_cup.yaml
+++ b/configs/train_tsdiff/train_missing_kdd_cup.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_solar.yaml
+++ b/configs/train_tsdiff/train_missing_solar.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_traffic.yaml
+++ b/configs/train_tsdiff/train_missing_traffic.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_missing_uber_tlc.yaml
+++ b/configs/train_tsdiff/train_missing_uber_tlc.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_solar.yaml
+++ b/configs/train_tsdiff/train_solar.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_traffic.yaml
+++ b/configs/train_tsdiff/train_traffic.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_uber_tlc.yaml
+++ b/configs/train_tsdiff/train_uber_tlc.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False

--- a/configs/train_tsdiff/train_wiki.yaml
+++ b/configs/train_tsdiff/train_wiki.yaml
@@ -1,4 +1,5 @@
 model: unconditional
+model_type: tsdiff
 diffusion_config: diffusion_small_config
 normalization: mean
 use_features: False


### PR DESCRIPTION
## Summary
- add FourierDiffusion to training script and map model names
- instantiate model based on `model_type`
- expose `model_type` option in training configs

## Testing
- `pytest -q`
- `python -m py_compile bin/train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68c760427f208329ac78af1ef4504acb