### PR TITLE
Add Fourier diffusion config and sample YAML

### DIFF
--- a/configs/train_fdiff/example.yaml
+++ b/configs/train_fdiff/example.yaml
@@ -1,0 +1,2 @@
+model_type: fourier
+diffusion_config: fourier_diffusion_config

--- a/src/uncond_ts_diff/configs.py
+++ b/src/uncond_ts_diff/configs.py
@@ -68,6 +68,15 @@ residual_block_s4_backbone_large = {
     "residual_block": "s4",
 }
 
+fourier_backbone = {
+    "input_dim": 1,
+    "hidden_dim": 64,
+    "output_dim": 1,
+    "step_emb": 128,
+    "num_residual_blocks": 3,
+    "residual_block": "s4",
+}
+
 
 diffusion_config = {
     "backbone_parameters": residual_block_s4_backbone,
@@ -110,3 +119,28 @@ diffusion_large_config = {
     "timesteps": 100,
     "diffusion_scheduler": linear_beta_schedule,
 }
+
+fourier_diffusion_config = {
+    "backbone_parameters": fourier_backbone,
+    "timesteps": 100,
+    "diffusion_scheduler": linear_beta_schedule,
+}
+
+__all__ = [
+    "residual_block_s4_backbone",
+    "residual_block_s4_backbone_smallv2",
+    "residual_block_s4_backbone_small",
+    "residual_block_s4_backbone_small_dropout01",
+    "residual_block_s4_backbone_small_dropout02",
+    "residual_block_s4_backbone_small_dropout03",
+    "residual_block_s4_backbone_large",
+    "fourier_backbone",
+    "diffusion_config",
+    "diffusion_small_config",
+    "diffusion_small_configv2",
+    "diffusion_small_config_dropout",
+    "diffusion_small_config_dropout02",
+    "diffusion_small_config_dropout03",
+    "diffusion_large_config",
+    "fourier_diffusion_config",
+]


### PR DESCRIPTION
## Summary
- add Fourier backbone and diffusion configuration with exports
- provide example training configuration using new Fourier diffusion config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c760482d888329bf7211f4087ed4a4