### PR TITLE
docs: add FourierDiffusion usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ python bin/train_cond_model.py -c configs/train_tsdiff-cond/missing_BM-E_kdd_cup
 ```
 Note that for TSDiff we train only one model and all the missing value scenarios are evaluated using the same unconditional model. However, for TSDiff-Cond, one model is trained per missingness scenario.
 
+### FourierDiffusion
+
+To train the FourierDiffusion variant set `model_type: fdiff` in the configuration. A minimal example configuration is provided in `configs/train_fdiff.yaml`:
+
+```yaml
+model: unconditional
+model_type: fdiff
+diffusion_config: diffusion_small_config
+normalization: mean
+use_features: False
+use_lags: False
+dataset: solar_nips
+freq: H
+context_length: 336
+prediction_length: 24
+```
+
+Example commands:
+
+```sh
+# Train FourierDiffusion
+python bin/train_model.py -c configs/train_fdiff.yaml
+
+# Evaluate a trained FourierDiffusion checkpoint
+python bin/guidance_experiment.py -c configs/guidance/guidance_solar.yaml --model_type fdiff --ckpt /path/to/ckpt
+```
+
 ### Evaluating Models
 The unconditional models trained above can be used for the following tasks.
 

--- a/configs/train_fdiff.yaml
+++ b/configs/train_fdiff.yaml
@@ -1,0 +1,36 @@
+model: unconditional
+model_type: fdiff
+diffusion_config: diffusion_small_config
+normalization: mean
+use_features: False
+use_lags: False
+dataset: solar_nips
+freq: H
+context_length: 336
+prediction_length: 24
+lr: 1.e-3
+init_skip: True
+gradient_clip_val: 0.5
+max_epochs: 100
+num_batches_per_epoch: 128
+batch_size: 64
+scale: 4
+# Used only in callback,
+# the final evaluation uses 100 samples
+num_samples: 16
+sampler: ddpm
+sampler_params:
+  guidance: quantile
+  scale: 4
+use_validation_set: True
+eval_every: 50
+device: cuda:0
+setup: forecasting
+do_final_eval: True
+# The following key will be ignored,
+# if the setup is forecasting
+missing_data_configs:
+- missing_scenario: BM-B
+  missing_values: 168
+- missing_scenario: BM-E
+  missing_values: 168


### PR DESCRIPTION
## Summary
- document how to enable FourierDiffusion with `model_type: fdiff`
- add training and evaluation command examples for FourierDiffusion
- provide a sample `train_fdiff.yaml` config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c760507cb48329894e1fd6632da691