### PR TITLE
feat: support FourierDiffusion in guidance experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Example commands:
 ```sh
 # Run observation self-guidance on the Solar dataset
 python bin/guidance_experiment.py -c configs/guidance/guidance_solar.yaml --ckpt /path/to/ckpt
+# Add `--model_type fdiff` when evaluating FourierDiffusion checkpoints
 
 python /home/shihongyue/unconditional-time-series-diffusion/bin/guidance_experiment.py -c /home/shihongyue/unconditional-time-series-diffusion/configs/guidance/guidance_nasdaq100.yaml --ckpt /home/shihongyue/unconditional-time-series-diffusion/lightning_logs/version_11/best_checkpoint.ckpt
 

--- a/bin/guidance_experiment.py
+++ b/bin/guidance_experiment.py
@@ -18,7 +18,7 @@ from uncond_ts_diff.utils import (
     filter_metrics,
     MaskInput,
 )
-from uncond_ts_diff.model import TSDiff
+from uncond_ts_diff.model import FourierDiffusion, TSDiff
 from uncond_ts_diff.dataset import get_gts_dataset
 from uncond_ts_diff.sampler import (
     DDPMGuidance,
@@ -30,7 +30,12 @@ guidance_map = {"ddpm": DDPMGuidance, "ddim": DDIMGuidance}
 
 
 def load_model(config):
-    model = TSDiff(
+    if config.get("model_type") == "fdiff":
+        Model = FourierDiffusion
+    else:
+        Model = TSDiff
+
+    model = Model(
         **getattr(
             diffusion_configs,
             config.get("diffusion_config", "diffusion_small_config"),

--- a/configs/guidance.yaml
+++ b/configs/guidance.yaml
@@ -1,5 +1,6 @@
 # Model & checkpoint parameters
 dataset: solar_nips
+model_type: tsdiff  # use "fdiff" for FourierDiffusion
 freq: H
 device: cuda:0
 ckpt: ckpts/forecasting/solar_nips/649_.ckpt


### PR DESCRIPTION
## Summary
- allow guidance experiment to load FourierDiffusion via `model_type`
- document `model_type` option in guidance config and README

## Testing
- `python -m py_compile bin/guidance_experiment.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7efab545c83299dcbbe76b5b8caeb